### PR TITLE
Empty star got wrong unicode character (from half star)

### DIFF
--- a/static/aliases.json
+++ b/static/aliases.json
@@ -3999,7 +3999,7 @@
     "faName": "star-empty",
     "fuiName": "star empty",
     "className": "star.empty",
-    "unicode": "f089",
+    "unicode": "f005",
     "solid": true,
     "outline": false,
     "brand": false,


### PR DESCRIPTION
## Description
The `empty star` got a wrongly assigned unicode character \f089 (which is `half empty star`) instead of \f005 (which is the star)

## Testcase
https://jsfiddle.net/Lm1n8rs5/
Remove CSS to see the issue

## Closes
https://github.com/Semantic-Org/Semantic-UI/issues/6729